### PR TITLE
1st stab at support for the RECORD datatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,19 @@ Scala provides syntactic sugar that Avro tuples do not. In Scala, you don't need
 
 ### Limited number of types
 
-For now, Avro tuples can be comprised of null values, strings, booleans, floats, doubles, ints, and longs. Support for more types is coming, e.g. `Option`.
+For now, Avro tuples can be comprised of null values, strings, booleans, floats, doubles, ints, longs, and records (case classes that implement `SpecificRecordBase`). Support for more types is coming, e.g. `Option`.
+
+### Records are hard to use
+
+To use a record dataype in an Avro tuple, their schemas must be loaded before any Avro tuple is used:
+```scala
+val userRecordSchemas = List(AvroRecordTestClass.SCHEMA$)
+AvroTupleSchemas.addRecordSchemas(userRecordSchemas)
+```
+and deserialized records require an extra cast if one is to use their field values:
+```scala
+AvroTuple1.fromBytes(tuple.toBytes)._1.asInstanceOf[AvroRecordTestClass].x
+```
 
 ### Recursive schemas break Parquet
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "avrotuples"
 
-version := "0.2"
+version := "0.3-SNAPSHOT"
 
 organization := "com.github.massie"
 

--- a/src/main/scala/com/github/massie/avrotuples/AvroTupleSchemas.scala
+++ b/src/main/scala/com/github/massie/avrotuples/AvroTupleSchemas.scala
@@ -19,6 +19,7 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Field
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ArrayBuffer
 
 object AvroTupleSchemas {
 
@@ -31,12 +32,18 @@ object AvroTupleSchemas {
     Schema.create(Schema.Type.INT),
     Schema.create(Schema.Type.LONG))
 
+  val recordSchemasArray: ArrayBuffer[Schema] = ArrayBuffer()
+
+  def addRecordSchemas(newRecordSchemas: List[Schema]) = {
+    newRecordSchemas.foreach(rs => recordSchemasArray += rs)
+  }
+
   def generateSchemas(recursive: Boolean): Array[Schema] = {
     val rootSchemas: Array[Schema] = Array.tabulate[Schema](22) { i =>
       Schema.createRecord(s"com.github.massie.avrotuples.AvroTuple${i+1}", "", "", false)
     }
     val avroTypes = recursive match {
-      case true => PRIMITIVE_TYPES ++ rootSchemas
+      case true => PRIMITIVE_TYPES ++ recordSchemasArray ++ rootSchemas
       case false => PRIMITIVE_TYPES
     }
     for (schema <- rootSchemas) {
@@ -47,8 +54,8 @@ object AvroTupleSchemas {
 
   val SCHEMA: Array[Schema] = Array.empty
 
-  val SCHEMAS: Array[Schema] = generateSchemas(true)
-  val FLAT_SCHEMAS: Array[Schema] = generateSchemas(false)
+  lazy val SCHEMAS: Array[Schema] = generateSchemas(true)
+  lazy val FLAT_SCHEMAS: Array[Schema] = generateSchemas(false)
 
   def main(args: Array[String]): Unit = {
     println(SCHEMAS(10).toString(true))

--- a/src/test/scala/com/github/massie/avrotuples/AvroRecordTestClass.scala
+++ b/src/test/scala/com/github/massie/avrotuples/AvroRecordTestClass.scala
@@ -1,0 +1,30 @@
+package com.github.massie.avrotuples
+
+case class AvroRecordTestClass(var x: String) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this("")
+  def get(field: Int): AnyRef = {
+    field match {
+      case pos if pos == 0 => {
+        x
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field: Int, value: Any): Unit = {
+    field match {
+      case pos if pos == 0 => this.x = {
+        value match {
+          case (value: org.apache.avro.util.Utf8) => value.toString
+          case _ => value
+        }
+      }.asInstanceOf[String]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = AvroRecordTestClass.SCHEMA$
+}
+
+object AvroRecordTestClass {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"AvroRecordTestClass\",\"namespace\":\"com.github.massie.avrotuples\",\"doc\":\"Auto-Generated Schema\",\"fields\":[{\"name\":\"x\",\"type\":\"string\",\"doc\":\"Auto-Generated Field\"}]}")
+}

--- a/src/test/scala/com/github/massie/avrotuples/AvroTupleSuite.scala
+++ b/src/test/scala/com/github/massie/avrotuples/AvroTupleSuite.scala
@@ -23,6 +23,9 @@ import org.scalatest.FunSuite
 
 class AvroTupleSuite extends FunSuite {
 
+  val userRecordSchemas = List(AvroRecordTestClass.SCHEMA$)
+  AvroTupleSchemas.addRecordSchemas(userRecordSchemas)
+
   test("AvroTuples have an empty ctor for serialization") {
     val tuple = new AvroTuple2()
     assert(tuple != null)
@@ -47,6 +50,13 @@ class AvroTupleSuite extends FunSuite {
   test("AvroTuples can have null values") {
     val tuple = AvroTuple3(null, 0xCAFE, null)
     assert(AvroTuple3.fromBytes(tuple.toBytes) == tuple)
+  }
+
+  test("AvroTuples can have record values") {
+    val tuple = AvroTuple1(AvroRecordTestClass("A-OK full go"))
+    assert(AvroTuple1.fromBytes(tuple.toBytes) == tuple)
+    assert(AvroTuple1.fromBytes(tuple.toBytes)._1
+      .asInstanceOf[AvroRecordTestClass].x == "A-OK full go")
   }
 
   test("Avro Tuples can be (de)serialized to Avro") {


### PR DESCRIPTION
Hey Matt, cool project!

I wanted to see if case classes would work in Avro tuples, so I added support for the RECORD datatype. Didn't come out as cleanly as I'd hoped though, so no worries here if you'd prefer not to merge this. 

At first I was daunted by the schemas, but they were eventually easy enough to figure out, and your app is so wonderfully light that I see how it's worth it.

Obviously there's a challenge in adding arbitrary record schemas, and without using macros, the compromises that I made were:
1) extra user step if the user wants to put a record in a tuple: `AvroTupleSchemas.addRecordSchemas(recordSchemas: List[Schema])`
2) the extra step must come before any Avro tuple is used
3) a mutable object is used (ArrayBuffer)
4) an extra cast must be made after deserializing if the user wants to use a case class' field value

So, works but not ideally.
#4 is a little odd to me because, in my experience, nested case class Avro records don't require an extra cast to use the nested record's field value. Something must be different about the way Avro tuple is deserializing generically that loses hifi type info in a weird way:

AvroTupleSuite.scala:59: type mismatch;
[error]  found   : _$7 where type _$7
[error]  required: ?{def x: ?}
[error] Note that implicit conversions are not applicable because they are ambiguous:
[error]  both method any2Ensuring in object Predef of type [A](x: A)Ensuring[A]
[error]  and method any2ArrowAssoc in object Predef of type [A](x: A)ArrowAssoc[A]
[error]  are possible conversion functions from _$7 to ?{def x: ?}
[error]     assert(AvroTuple1.fromBytes(tuple.toBytes)._1
[error]                                                ^

I'm not too familiar with implicit conversions or type classes as of now, but my tinkering failed to resolve this without the cast. Happen to know what's going on here?

Cheers, and thanks for the project.
